### PR TITLE
fix(*): replace seconds with s

### DIFF
--- a/src/iplot.jl
+++ b/src/iplot.jl
@@ -19,7 +19,7 @@ function InteractiveViz.iplot(s::SampleBuf, args...; kwargs...)
     t *= 1000.0
     xlabel = "Time (ms)"
   else
-    xlabel = "Time (seconds)"
+    xlabel = "Time (s)"
   end
   iplot(t, s1, args...; xlabel=xlabel, kwargs...)
 end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -22,7 +22,7 @@ Plots timeseries from a sample buffer.
     t *= 1000.0
     xguide --> "Time (ms)"
   else
-    xguide --> "Time (seconds)"
+    xguide --> "Time (s)"
   end
   n = size(s1, 1)
   if downsample == :auto
@@ -96,7 +96,7 @@ Displays time frequency representation.
     t *= 1000.0
     xguide --> "Time (ms)"
   else
-    xguide --> "Time (seconds)"
+    xguide --> "Time (s)"
   end
   if maximum(f) >= 5000.0
     f /= 1000.0


### PR DESCRIPTION
```julia
using InteractiveViz
using SignalAnalysis 

fs = 4800
N = 48000
x = randn(N)

iplot(signal(x, fs))
ispecgram(signal(x, fs))
```

Before the PR:
![timeseries-before](https://user-images.githubusercontent.com/5800038/90159507-1346f500-ddc3-11ea-96f7-b195b2c815f4.png)
![specgram-before](https://user-images.githubusercontent.com/5800038/90159948-b0099280-ddc3-11ea-8fb8-ddb532f731e2.png)

After the PR:
![timeseries-after](https://user-images.githubusercontent.com/5800038/90159831-86e90200-ddc3-11ea-94a2-757d201d4aba.png)
![specgram-after](https://user-images.githubusercontent.com/5800038/90159965-b6980a00-ddc3-11ea-9ab2-4634d066adf2.png)
