### PR TITLE
feat(*): add istft and spectralwhitening

### DIFF
--- a/src/dsp.jl
+++ b/src/dsp.jl
@@ -434,7 +434,7 @@ julia> x = randn(1024)
   2.6158861993992533
   1.2980813993011973
  -0.010592954871694647
-julia> X = stft(x, nfft, 0)
+julia> X = stft(x, 64, 0)
 33×31 Array{Complex{Float64},2}:
   ⋮
 julia> x̂ = istft(X; nfft=64, noverlap=0)

--- a/src/dsp.jl
+++ b/src/dsp.jl
@@ -420,7 +420,7 @@ for description of optional keyword arguments.
 
 For perfect reconstruction, the parameters `n`, `noverlap` and `window` in `stft` and 
 `istft` have to be the same, and the windowing must obey the constraint of "nonzero overlap add" (NOLA).  
-Implementation based on Hristo 2019 and `istft` in `scipy`. 
+Implementation based on Zhivomirov 2019 and `istft` in `scipy`. 
 
 H. Zhivomirov. On the Development of STFT-analysis and ISTFT-synthesis Routines 
 and their Practical Implementation. TEM Journal, ISSN: 2217-8309, DOI: 10.18421/TEM81-07, 
@@ -481,15 +481,18 @@ end
 
 """
 $(SIGNATURES)
-Spectral whitening/flattening in the frequency domain.
+Spectral whitening of input signal `x`. The parameters `n`, `noverlap` and 
+`window` are required for the computation of STFT coefficients of `x`. Refer to 
+`DSP.Periodograms.spectrogram` for description of the parameters. `γ` is a scaling 
+or degree-of-flattening factor. The algorithm is based on Lee 1986.
 
 M. W. Lee, Spectral whitening in the frequency domain, 1986.
 """
-function spectralwhitening(x::AbstractVector, 
-                           n::Int, 
-                           noverlap::Int; 
-                           window::Union{Function,AbstractVector,Nothing}=nothing,
-                           γ=1)
+function whiten(x::AbstractVector, 
+                n::Int, 
+                noverlap::Int; 
+                window::Union{Function,AbstractVector,Nothing}=nothing,
+                γ=1)
   xstft = stft(x, n, noverlap; window=window)
   mag = abs.(xstft)
   logmag = log.(mag .+ eps(eltype(mag)))

--- a/src/dsp.jl
+++ b/src/dsp.jl
@@ -422,11 +422,6 @@ For perfect reconstruction, the parameters `nfft`, `noverlap` and `window` in `s
 `istft` have to be the same, and the windowing must obey the constraint of "nonzero overlap add" (NOLA).  
 Implementation based on Zhivomirov 2019 and `istft` in `scipy`. 
 
-H. Zhivomirov. On the Development of STFT-analysis and ISTFT-synthesis Routines 
-and their Practical Implementation. TEM Journal, ISSN: 2217-8309, DOI: 10.18421/TEM81-07, 
-Vol. 8, No. 1, pp. 56-64, Feb. 2019. 
-(http://www.temjournal.com/content/81/TEMJournalFebruary2019_56_64.pdf)
-
 # Examples:
 ```julia-repl
 julia> x = randn(1024)
@@ -458,6 +453,7 @@ function istft(X::AbstractMatrix{Complex{T}};
                noverlap::Int, 
                onesided::Bool=true, 
                window::Union{Function,AbstractVector,Nothing}=nothing) where {T<:AbstractFloat}
+  # H. Zhivomirov, TEM Journal, Vol. 8, No. 1, pp. 56-64, 2019. 
   (window === nothing) && (window = rect)
   win, norm2 = Periodograms.compute_window(window, nfft)
 
@@ -481,18 +477,17 @@ end
 
 """
 $(SIGNATURES)
-Spectral whitening of input signal `x`. The parameters `nfft`, `noverlap` and 
-`window` are required for the computation of STFT coefficients of `x`. Refer to 
-`DSP.Periodograms.spectrogram` for description of the parameters. `γ` is a scaling 
-or degree-of-flattening factor. The algorithm is based on Lee 1986.
-
-M. W. Lee, Spectral whitening in the frequency domain, 1986.
+Spectral whitening of input signal `x` in the frequency domain. The parameters `nfft`, 
+`noverlap` and `window` are required for the computation of STFT coefficients of `x`. 
+Refer to `DSP.Periodograms.spectrogram` for description of the parameters. `γ` is a 
+scaling or degree-of-flattening factor. The algorithm is based on Lee 1986.
 """
 function whiten(x::AbstractVector; 
                 nfft::Int, 
                 noverlap::Int,
                 window::Union{Function,AbstractVector,Nothing}=nothing,
                 γ=1)
+  # M. W. Lee, Open-File Report 86-108, 1986.
   xstft = stft(x, nfft, noverlap; window=window)
   mag = abs.(xstft)
   logmag = log.(mag .+ eps(eltype(mag)))

--- a/src/dsp.jl
+++ b/src/dsp.jl
@@ -414,19 +414,44 @@ end
 
 """
 $(SIGNATURES)
-Inverse Short Time Fourier Transform (ISTFT). 
+Compute the inverse short time Fourier transform (ISTFT) of STFT coefficients `X` which is based
+on segments with `n` samples with overlap of `noverlap` samples. Refer to `DSP.Periodograms.spectrogram` 
+for description of optional keyword arguments.
 
-The signal windowing must obey the constraint of "nonzero overlap add" (NOLA). 
-Implementation based on Hristo (2019, 2020) and `istft` in `scipy`. 
+For perfect reconstruction, the parameters `n`, `noverlap` and `window` in `stft` and 
+`istft` have to be the same, and the windowing must obey the constraint of "nonzero overlap add" (NOLA).  
+Implementation based on Hristo 2019 and `istft` in `scipy`. 
 
 H. Zhivomirov. On the Development of STFT-analysis and ISTFT-synthesis Routines 
 and their Practical Implementation. TEM Journal, ISSN: 2217-8309, DOI: 10.18421/TEM81-07, 
 Vol. 8, No. 1, pp. 56-64, Feb. 2019. 
 (http://www.temjournal.com/content/81/TEMJournalFebruary2019_56_64.pdf)
 
-Hristo Zhivomirov (2020). Inverse Short-Time Fourier Transform (ISTFT) with Matlab 
-(https://www.mathworks.com/matlabcentral/fileexchange/45577-inverse-short-time-fourier-transform-istft-with-matlab), 
-MATLAB Central File Exchange. Retrieved October 21, 2020. 
+# Examples:
+```julia-repl
+julia> x = randn(1024)
+1024-element Array{Float64,1}:
+ -0.7903319156212055
+ -0.564789077302601
+  0.8621044972211616
+  0.9351928359709288
+  ⋮
+  2.6158861993992533
+  1.2980813993011973
+ -0.010592954871694647
+julia> X = stft(x, 64, 0)
+33×31 Array{Complex{Float64},2}:
+  ⋮
+julia> x̂ = istft(X, 64, 0)
+1024-element Array{Float64,1}:
+ -0.7903319156212054
+ -0.5647890773026012
+  0.8621044972211612
+  0.9351928359709288
+  ⋮
+  2.6158861993992537
+  1.2980813993011973
+ -0.010592954871694371
 """
 function istft(X::AbstractMatrix{Complex{T}}, 
                n::Int, 

--- a/src/dsp.jl
+++ b/src/dsp.jl
@@ -477,7 +477,6 @@ function istft(X::AbstractMatrix{Complex{T}},
   (sum(normw[n÷2:end-n÷2] .> 1e-10) != length(normw[n÷2:end-n÷2])) && (
       @warn "NOLA condition failed, STFT may not be invertible")
   x .*= nstep/norm2
-  x
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -452,9 +452,9 @@ end
   @test argmax(abs.(x2)) == 1001
 
   onesideds = [true, false]
-  n = 256
-  windows = [nothing, rect, tukey(n, 0.5), hanning, hamming]
-  noverlaps = [0, 0, (15*n)÷16, (5*n)÷6, (5*n)÷6]
+  nfft = 256
+  windows = [nothing, rect, tukey(nfft, 0.5), hanning, hamming]
+  noverlaps = [0, 0, (15*nfft)÷16, (5*nfft)÷6, (5*nfft)÷6]
   for onesided in onesideds
     if onesided === true
       x = randn(96000)
@@ -462,9 +462,9 @@ end
       x = randn(96000) + im .* randn(96000)
     end    
     for (window, noverlap) in zip(windows, noverlaps)  
-      xstft = stft(x, n, noverlap; window=window, onesided=onesided)
-      x̂ = istft(xstft, n, noverlap; window=window, onesided=onesided)
-      @test rms(x[n:length(x̂)-n]-x̂[n:end-n]) / rms(x[n:length(x̂)-n]) ≈ 0. atol=0.001
+      xstft = stft(x, nfft, noverlap; window=window, onesided=onesided)
+      x̂ = istft(xstft; nfft=nfft, noverlap=noverlap, window=window, onesided=onesided)
+      @test rms(x[nfft:length(x̂)-nfft]-x̂[nfft:end-nfft]) / rms(x[nfft:length(x̂)-nfft]) ≈ 0. atol=0.001
     end
   end
 
@@ -473,12 +473,12 @@ end
   x = filtfilt(hpf, randn(96000))
   y = 0.1 .* real(chirp(500, 1000, 1.0, fs))
   x[9600+1:2*9600] .+= y
-  n = 256
+  nfft = 256
   noverlap = 0
-  x̃ = spectralwhitening(x, n, noverlap; window=nothing)
+  x̃ = whiten(x; nfft=nfft, noverlap=noverlap, window=nothing)
   ỹ = x̃[9600+1:2*9600]
   @test cor(y, ỹ) > 0.3
-  x̃ = spectralwhitening(x, n, noverlap; window=nothing, γ=0.)
+  x̃ = whiten(x; nfft=nfft, noverlap=noverlap, window=nothing, γ=0.)
   @test rms(x[1:length(x̃)] - x̃) / rms(x[1:length(x̃)]) ≈ 0. atol=0.0001
 
 end


### PR DESCRIPTION
This PR adds support for spectral whitening/flattening in the frequency domain (`spectralwhitening`). Inverse short time Fourier transform (`istft`) is included since the function is not yet implemented in DSP.jl. The figures below show chirp spectrograms without and with `spectralwhitening`.
![xp0](https://user-images.githubusercontent.com/5800038/97101328-744e4b80-16d7-11eb-83c6-470547f95ee8.png)
![xp](https://user-images.githubusercontent.com/5800038/97101331-77e1d280-16d7-11eb-84aa-9074e00024ae.png)

