### PR TITLE
Improve `istft`

### DIFF
--- a/src/dsp.jl
+++ b/src/dsp.jl
@@ -518,11 +518,11 @@ function _istft(iX::AbstractMatrix{T},
   x = zeros(T, outputlength)
   normw = zeros(eltype(win), outputlength)
   for i = 1:nseg
-      x[1+(i-1)*nstep:nfft+(i-1)*nstep] += iX[:,i]
-      normw[1+(i-1)*nstep:nfft+(i-1)*nstep] += win .^ 2
+      x[1+(i-1)*nstep:nfft+(i-1)*nstep] = @view(x[1+(i-1)*nstep:nfft+(i-1)*nstep]) + @view(iX[:,i])
+      normw[1+(i-1)*nstep:nfft+(i-1)*nstep] = @view(normw[1+(i-1)*nstep:nfft+(i-1)*nstep]) + win .^ 2
   end
 
-  (sum(normw[nfft÷2:end-nfft÷2] .> 1e-10) != length(normw[nfft÷2:end-nfft÷2])) && (
+  (sum(@view(normw[nfft÷2:end-nfft÷2]) .> 1e-10) != length(@view(normw[nfft÷2:end-nfft÷2]))) && (
       @warn "NOLA condition failed, STFT may not be invertible")
   x .*= nstep/norm2
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -465,6 +465,7 @@ end
       xstft = stft(x, nfft, noverlap; window=window, onesided=onesided)
       outputtype = isreal(x) ? Real : Complex
       x̂ = istft(outputtype, xstft; nfft=nfft, noverlap=noverlap, window=window)
+      outputtype === Complex && (@test x̂ == istft(xstft; nfft=nfft, noverlap=noverlap, window=window))
       @test rms(x[nfft:length(x̂)-nfft]-x̂[nfft:end-nfft]) / rms(x[nfft:length(x̂)-nfft]) ≈ 0. atol=0.001
     end
   end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -463,7 +463,8 @@ end
     end    
     for (window, noverlap) in zip(windows, noverlaps)  
       xstft = stft(x, nfft, noverlap; window=window, onesided=onesided)
-      x̂ = istft(xstft; nfft=nfft, noverlap=noverlap, window=window, onesided=onesided)
+      outputtype = isreal(x) ? Real : Complex
+      x̂ = istft(outputtype, xstft; nfft=nfft, noverlap=noverlap, window=window)
       @test rms(x[nfft:length(x̂)-nfft]-x̂[nfft:end-nfft]) / rms(x[nfft:length(x̂)-nfft]) ≈ 0. atol=0.001
     end
   end


### PR DESCRIPTION
The PR improves `istft` by
- enforcing type stability;
- using subarray for efficient array slicing

```julia
x = randn(9600000)
S = stft(x, 1024, 0)
```

Before:
```julia
@btime istft(S; nfft=1024, noverlap=0)
# 180.449 ms (65693 allocations: 813.96 MiB)
```
After:
```julia
@btime istft(Real, S; nfft=1024, noverlap=0)
# 130.942 ms (28186 allocations: 444.05 MiB)
```