### PR TITLE
fix: rand for any float types

### DIFF
--- a/src/rand.jl
+++ b/src/rand.jl
@@ -53,7 +53,7 @@ PinkGaussian(n) = PinkGaussian(n=n)
 function Random.rand!(rng::AbstractRNG, d::RedGaussian{T}, x::AbstractVector{T}) where {T<:Real}
   length(x) >= d.n || throw(ArgumentError("length of x must be at least n"))
   extra = 100
-  v = rand(rng, Normal{T}(convert(T, 0.0), d.σ), length(x)+extra)
+  v = rand(rng, Normal{T}(zero(T), d.σ), length(x)+extra)
   for j = 2:length(v)
     v[j] += v[j-1]
   end
@@ -68,7 +68,7 @@ function Random.rand!(rng::AbstractRNG, d::PinkGaussian{T}, x::AbstractVector{T}
   hb = [0.049922035, -0.095993537, 0.050612699, -0.004408786]
   ha = [1.0, -2.494956002, 2.017265875, -0.522189400]
   extra = 1430
-  v = rand(rng, Normal{T}(convert(T, 0.0), d.σ), length(x)+extra)
+  v = rand(rng, Normal{T}(zero(T), d.σ), length(x)+extra)
   v = filt(hb, ha, v)/0.08680587859687908
   x .= v[extra+1:end]
   return x

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -53,7 +53,7 @@ PinkGaussian(n) = PinkGaussian(n=n)
 function Random.rand!(rng::AbstractRNG, d::RedGaussian{T}, x::AbstractVector{T}) where {T<:Real}
   length(x) >= d.n || throw(ArgumentError("length of x must be at least n"))
   extra = 100
-  v = rand(rng, Normal{T}(0.0,d.σ), length(x)+extra)
+  v = rand(rng, Normal{T}(convert(T, 0.0), d.σ), length(x)+extra)
   for j = 2:length(v)
     v[j] += v[j-1]
   end
@@ -68,7 +68,7 @@ function Random.rand!(rng::AbstractRNG, d::PinkGaussian{T}, x::AbstractVector{T}
   hb = [0.049922035, -0.095993537, 0.050612699, -0.004408786]
   ha = [1.0, -2.494956002, 2.017265875, -0.522189400]
   extra = 1430
-  v = rand(rng, Normal{T}(0.0,d.σ), length(x)+extra)
+  v = rand(rng, Normal{T}(convert(T, 0.0), d.σ), length(x)+extra)
   v = filt(hb, ha, v)/0.08680587859687908
   x .= v[extra+1:end]
   return x
@@ -77,5 +77,5 @@ end
 Base.length(d::RedGaussian) = d.n
 Base.length(d::PinkGaussian) = d.n
 
-Base.rand(rng::AbstractRNG, d::RedGaussian) = Random.rand!(rng, d, zeros(d.n))
-Base.rand(rng::AbstractRNG, d::PinkGaussian) = Random.rand!(rng, d, zeros(d.n))
+Base.rand(rng::AbstractRNG, d::RedGaussian) = Random.rand!(rng, d, zeros(typeof(d.σ), d.n))
+Base.rand(rng::AbstractRNG, d::PinkGaussian) = Random.rand!(rng, d, zeros(typeof(d.σ), d.n))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -513,8 +513,8 @@ end
 
   types = [Float16, Float32, Float64]
   for t ∈ types
-    @test eltype(rand(RedGaussian(1000, convert(t, 1.0)))) == t
-    @test eltype(rand(PinkGaussian(1000, convert(t, 1.0)))) == t
+    @test eltype(rand(RedGaussian(1000, one(t)))) == t
+    @test eltype(rand(PinkGaussian(1000, one(t)))) == t
   end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -511,6 +511,12 @@ end
   end
   @test 0 < log10(x1/x2) < 2
 
+  types = [Float16, Float32, Float64]
+  for t ∈ types
+    @test eltype(rand(RedGaussian(1000, convert(t, 1.0)))) == t
+    @test eltype(rand(PinkGaussian(1000, convert(t, 1.0)))) == t
+  end
+
 end
 
 @testset "plots" begin


### PR DESCRIPTION
Errors occur when generating random Red Gaussian and Pink Gaussian noise of any float types.
```julia
julia> rand(RedGaussian(1000, convert(Float32, 1.0)))
ERROR: MethodError: no method matching _rand!(::Random._GLOBAL_RNG, ::RedGaussian{Float32}, ::Array{Float64,1})

julia> rand(PinkGaussian(1000, convert(Float32, 1.0)))
ERROR: MethodError: no method matching _rand!(::Random._GLOBAL_RNG, ::PinkGaussian{Float32}, ::Array{Float64,1})
```
After the changes:
```julia
julia> rand(RedGaussian(1000, convert(Float32, 1.0)))
1000-element Array{Float32,1}:
 -0.61762047
  0.026895309
 -0.112934574
  ⋮
 -0.33766067
 -0.964278
 -1.4871243

julia> rand(PinkGaussian(1000, convert(Float32, 1.0)))
1000-element Array{Float32,1}:
 1.1732337
 0.46513683
 0.6875517
 ⋮
 1.5279891
 1.1409322
 1.3683038
```