### PR TITLE
fix(iplot): rescale time domain

### DIFF
--- a/src/iplot.jl
+++ b/src/iplot.jl
@@ -35,6 +35,7 @@ function InteractiveViz.iplot!(s::SampledSignal; kwargs...)
     s1 = real.(s1)
   end
   t = domain(s)
+  maximum(t) <= 1.0 && (t *= 1000.0)
   iplot!(t, s1; kwargs...)
 end
 


### PR DESCRIPTION
Plotting signals with variable length.
```julia
using SignalAnalysis
using InteractiveViz
using GLMakie

x1 = cw(1000, 0.5, 9600)
x2 = cw(1000, 0.1, 9600)
iplot(x1); iplot!(x2; color=:red) 
```
Before:
![Screenshot from 2021-05-06 18-30-20](https://user-images.githubusercontent.com/5800038/117284812-d6afb200-ae99-11eb-9452-b82bc78f5d3b.png)
After:
![Screenshot from 2021-05-06 18-22-11](https://user-images.githubusercontent.com/5800038/117284853-e0391a00-ae99-11eb-8d05-473ad79008e0.png)
