### PR TITLE
perf(array): reduce allocations using @views

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -128,7 +128,7 @@ function beamform(s, sd; fs=framerate(s))
   bfo = zeros(eltype(s), (nframes(s), ndir))
   for k ∈ 1:ndir
     for j ∈ 1:nchannels(s)
-      bfo[:,k] .+= padded(s[:,j], 0; delay=round(Int, -sd[j,k]*fs))
+      @views bfo[:,k] .+= padded(s[:,j], 0; delay=round(Int, -sd[j,k]*fs))
     end
   end
   signal(bfo, fs)


### PR DESCRIPTION
MWE:
```
c = 1500
θ = range(0.0, π; length=181)
sd = steering(0.0:1.0:5.0, c, θ)
s = signal(randn(9600,6), 9600)
```
Before:
```
@btime beamform(s, sd)
# 36.658 ms (4347 allocations: 172.44 MiB)
```
After:
```
@btime beamform(s, sd)
# 12.832 ms (3 allocations: 13.26 MiB)
```