### PR TITLE
fix: unsupported kwargs "dims" for sresample

### DIFF
--- a/src/dsp.jl
+++ b/src/dsp.jl
@@ -400,7 +400,7 @@ $(SIGNATURES)
 Same as [`resample`](https://docs.juliadsp.org/stable/filters/#DSP.Filters.resample),
 but correctly handles sampling rate conversion.
 """
-sresample(x, rate, args...) = signal(resample(samples(x), rate, args...), rate * framerate(x))
+sresample(x, rate, args...; kwargs...) = signal(resample(samples(x), rate, args...; kwargs...), rate * framerate(x))
 
 """
 $(SIGNATURES)


### PR DESCRIPTION
Before:
```
julia> sresample(signal(randn(10000, 10), 1000), 0.5; dims=1)
ERROR: MethodError: no method matching sresample(::MetaArrays.MetaArray{Matrix{Float64}, SignalAnalysis.SamplingInfo, Float64, 2}, ::Float64; dims=1)
Closest candidates are:
  sresample(::Any, ::Any, ::Any...) at ~/Projects/SignalAnalysis.jl/src/dsp.jl:403 got unsupported keyword argument "dims"
Stacktrace:
 [1] top-level scope
   @ REPL[27]:1
```
After:
```
julia> sresample(signal(randn(10000, 10), 1000), 0.5; dims=1)
SampledSignal @ 500.0 Hz, 5000×10 Matrix{Float64}:
  0.0932821   0.62886     …  -0.906615
 -0.0604339   0.531539        0.39423
```