### PR TITLE
v0.4.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SignalAnalysis"
 uuid = "df1fea92-c066-49dd-8b36-eace3378ea47"
 authors = ["Mandar Chitre <mandar@nus.edu.sg>"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"


### PR DESCRIPTION
we need to register a new version for the DocStringExtensions Fix to apply :)

Could you run 
```
@JuliaRegistrator register
Bump DocStringExtensions to include 0.9 for compatability reasons
```