### PR TITLE
Define `vec(s::SampledSignal)`

### DIFF
--- a/src/basic.jl
+++ b/src/basic.jl
@@ -5,7 +5,7 @@ $(SIGNATURES)
 Computes total signal energy.
 """
 energy(s::AbstractVector; fs=framerate(s)) = sum(abs2, s)/inHz(fs)
-energy(s::AbstractMatrix; fs=framerate(s)) = vec(sum(abs2, s; dims=1))./inHz(fs)
+energy(s::AbstractMatrix; fs=framerate(s)) = vec(samples(sum(abs2, s; dims=1)))./inHz(fs)
 
 """
 $(SIGNATURES)

--- a/src/signals.jl
+++ b/src/signals.jl
@@ -289,6 +289,6 @@ function Base.vec(s::SampledSignal)
   if ndims(s) < 3 && isone(size(s, 2))
     signal(reshape(samples(s), length(s)), framerate(s))
   else
-    throw(ArgumentError("reshape a multi-channel signal as a single-channel signal is undefined."))
+    vec(samples(s))
   end 
 end

--- a/src/signals.jl
+++ b/src/signals.jl
@@ -284,3 +284,5 @@ Base.getindex(s::SampledSignal, t::NTuple{2}) = Base.getindex(s, toframe(t[1], s
 Base.getindex(s::SampledSignal, t::NTuple{2}, ndx...) = Base.getindex(s, toframe(t[1], s):toframe(t[2], s), ndx...)
 Base.setindex!(s::SampledSignal, v, t::NTuple{2}) = Base.setindex!(s, v, toframe(t[1], s):toframe(t[2], s))
 Base.setindex!(s::SampledSignal, v, t::NTuple{2}, ndx...) = Base.setindex!(s, v, toframe(t[1], s):toframe(t[2], s), ndx...)
+
+Base.reshape(s::SampledSignal, dims::Union{Colon, Int64}...) = signal(reshape(samples(s), dims...), framerate(s))

--- a/src/signals.jl
+++ b/src/signals.jl
@@ -285,4 +285,4 @@ Base.getindex(s::SampledSignal, t::NTuple{2}, ndx...) = Base.getindex(s, toframe
 Base.setindex!(s::SampledSignal, v, t::NTuple{2}) = Base.setindex!(s, v, toframe(t[1], s):toframe(t[2], s))
 Base.setindex!(s::SampledSignal, v, t::NTuple{2}, ndx...) = Base.setindex!(s, v, toframe(t[1], s):toframe(t[2], s), ndx...)
 
-Base.reshape(s::SampledSignal, dims::Union{Colon, Int64}...) = signal(reshape(samples(s), dims...), framerate(s))
+Base.reshape(s::SampledSignal, dims::Union{Int,Colon}...) = signal(reshape(samples(s), dims...), framerate(s))

--- a/src/signals.jl
+++ b/src/signals.jl
@@ -287,8 +287,8 @@ Base.setindex!(s::SampledSignal, v, t::NTuple{2}, ndx...) = Base.setindex!(s, v,
 
 function Base.vec(s::SampledSignal) 
   if ndims(s) < 3 && isone(size(s, 2))
-    signal(reshape(samples(s), length(s)), framerate(s))
+    signal(vec(samples(s)), framerate(s))
   else
-    vec(samples(s))
+    throw(ArgumentError("reshape a multi-channel signal as a single-channel signal is undefined."))
   end 
 end

--- a/src/signals.jl
+++ b/src/signals.jl
@@ -285,4 +285,10 @@ Base.getindex(s::SampledSignal, t::NTuple{2}, ndx...) = Base.getindex(s, toframe
 Base.setindex!(s::SampledSignal, v, t::NTuple{2}) = Base.setindex!(s, v, toframe(t[1], s):toframe(t[2], s))
 Base.setindex!(s::SampledSignal, v, t::NTuple{2}, ndx...) = Base.setindex!(s, v, toframe(t[1], s):toframe(t[2], s), ndx...)
 
-Base.reshape(s::SampledSignal, dims::Union{Int,Colon}...) = signal(reshape(samples(s), dims...), framerate(s))
+function Base.vec(s::SampledSignal) 
+  if ndims(s) < 3 && isone(size(s, 2))
+    signal(reshape(samples(s), length(s)), framerate(s))
+  else
+    throw(ArgumentError("reshape a multi-channel signal as a single-channel signal is undefined."))
+  end 
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -145,17 +145,21 @@ using SignalAnalysis.Units
   t = toframe(0:0.1:1, x)
   @test t == 1:100:1001
 
-  for i ∈ 1:10
-    x = signal(randn(8000, i), 1000)
-    reshape_x = reshape(x, :)
-    vec_x = vec(x)
-    @test size(reshape_x) == size(vec_x) == (prod(size(x)),)
-    @test reshape_x == vec_x
-    @test framerate(reshape_x) == framerate(vec_x) == framerate(x)
-    reshape1_x = reshape(x, size(x)..., 1)
-    @test size(reshape1_x) == (size(x)..., 1)
-    @test reshape1_x[:,:,1] == x
-  end
+  xlen = 8000
+  x = randn(xlen)
+  fs = 1000
+  s0 = signal(x, fs)
+  @test vec(s0) == s0
+  @test framerate(s0) == fs
+  @test size(vec(s0)) == (xlen,)
+  s1 = signal(reshape(x, :, 1), fs)
+  @test vec(s1) == s0
+  @test framerate(s1) == fs
+  @test size(vec(s1)) == (xlen,)
+  s2 = signal(randn(8000, 2), fs)
+  @test_throws ArgumentError vec(s2)
+  s3 = signal(randn(8000, 1, 1), fs)
+  @test_throws ArgumentError vec(s3)
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -150,11 +150,11 @@ using SignalAnalysis.Units
   fs = 1000
   s0 = signal(x, fs)
   @test vec(s0) == s0
-  @test framerate(s0) == fs
+  @test framerate(vec(s0)) == fs
   @test size(vec(s0)) == (xlen,)
   s1 = signal(reshape(x, :, 1), fs)
   @test vec(s1) == s0
-  @test framerate(s1) == fs
+  @test framerate(vec(s1)) == fs
   @test size(vec(s1)) == (xlen,)
   s2 = signal(randn(8000, 2), fs)
   @test_throws ArgumentError vec(s2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -156,10 +156,12 @@ using SignalAnalysis.Units
   @test vec(s1) == s0
   @test framerate(vec(s1)) == fs
   @test size(vec(s1)) == (xlen,)
-  s2 = signal(randn(8000, 2), fs)
-  @test_throws ArgumentError vec(s2)
-  s3 = signal(randn(8000, 1, 1), fs)
-  @test_throws ArgumentError vec(s3)
+  x2 = randn(8000, 2)
+  s2 = signal(x2, fs)
+  @test vec(s2) == vec(x2)
+  x3 = randn(8000, 1, 1)
+  s3 = signal(x3, fs)
+  @test vec(s3) == vec(x3)
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -156,12 +156,10 @@ using SignalAnalysis.Units
   @test vec(s1) == s0
   @test framerate(vec(s1)) == fs
   @test size(vec(s1)) == (xlen,)
-  x2 = randn(8000, 2)
-  s2 = signal(x2, fs)
-  @test vec(s2) == vec(x2)
-  x3 = randn(8000, 1, 1)
-  s3 = signal(x3, fs)
-  @test vec(s3) == vec(x3)
+  s2 = signal(randn(xlen, 2), fs)
+  @test_throws ArgumentError vec(s2)
+  s3 = signal(randn(xlen, 1, 1), fs)
+  @test_throws ArgumentError vec(s3)
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -145,6 +145,18 @@ using SignalAnalysis.Units
   t = toframe(0:0.1:1, x)
   @test t == 1:100:1001
 
+  for i ∈ 1:10
+    x = signal(randn(8000, i), 1000)
+    reshape_x = reshape(x, :)
+    vec_x = vec(x)
+    @test size(reshape_x) == size(vec_x) == (prod(size(x)),)
+    @test reshape_x == vec_x
+    @test framerate(reshape_x) == framerate(vec_x) == framerate(x)
+    reshape1_x = reshape(x, size(x)..., 1)
+    @test size(reshape1_x) == (size(x)..., 1)
+    @test reshape1_x[:,:,1] == x
+  end
+
 end
 
 @testset "generate" begin


### PR DESCRIPTION
`reshape(s::SampledSignal, args...)` is undefined and hence the sampling rate is not retained:
```julia
julia> s = signal(randn(1000,1), 100)
SampledSignal @ 100.0 Hz, 1000×1 Matrix{Float64}:
 -1.1582512154996183
 -1.6624304955859712
  1.013253308849691
  ⋮
  0.555604245357521
 -0.3619263760688517

julia> reshape_s = reshape(s, :)
1000-element reshape(MetaArray(::Matrix{Float64}, (:fs,)), 1000) with eltype Float64:
 -1.1582512154996183
 -1.6624304955859712
  1.013253308849691
  ⋮
  0.555604245357521
 -0.3619263760688517

julia> vec_s = vec(s)
1000-element reshape(MetaArray(::Matrix{Float64}, (:fs,)), 1000) with eltype Float64:
 -1.1582512154996183
 -1.6624304955859712
  1.013253308849691
  ⋮
  0.555604245357521
 -0.3619263760688517

julia> framerate(s)
100.0f0

julia> framerate(reshape_s)
1.0

julia> framerate(vec_s)
1.0
```
After the change:
```julia
julia> framerate(reshape_s)
100.0f0

julia> framerate(vec_s)
100.0f0
```