### PR TITLE
Fix padded and partition of signals with custom indices

### DIFF
--- a/src/signals.jl
+++ b/src/signals.jl
@@ -224,7 +224,7 @@ function Base.length(itr::SignalPartitionIterator)
 end
 
 function Base.iterate(itr::SignalPartitionIterator{<:AbstractRange}, state=firstindex(itr.c))
-  l = length(itr.c)
+  l = lastindex(itr.c)
   state > l && return nothing
   itr.flush || state + itr.n - 1 <= l || return nothing
   r = min(state + itr.n - 1, l)
@@ -232,7 +232,7 @@ function Base.iterate(itr::SignalPartitionIterator{<:AbstractRange}, state=first
 end
 
 function Base.iterate(itr::SignalPartitionIterator{<:AbstractVector}, state=firstindex(itr.c))
-  l = length(itr.c)
+  l = lastindex(itr.c)
   state > l && return nothing
   itr.flush || state + itr.n - 1 <= l || return nothing
   r = min(state + itr.n - 1, l)
@@ -240,7 +240,7 @@ function Base.iterate(itr::SignalPartitionIterator{<:AbstractVector}, state=firs
 end
 
 function Base.iterate(itr::SignalPartitionIterator{<:AbstractMatrix}, state=firstindex(itr.c))
-  l = size(itr.c, 1)
+  l = lastindex(itr.c, 1)
   state > l && return nothing
   itr.flush || state + itr.n - 1 <= l || return nothing
   r = min(state + itr.n - 1, l)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,12 +88,34 @@ using SignalAnalysis.Units
   @test x1[1] == 0
   @test x1[2] == x[1]
   @test x1[8001] == x[8000]
+  x2 = padded(x1, (1, 1); delay=0)
+  @test x2[-10] == 0
+  @test x2[8006] == 0
+  @test x2[1] == 0
+  @test x2[8001] == x1[8001] == x[8000]
+  x2d = randn(8000, 2)
+  x2d1 = padded(x2d, (10, 5); delay=1)
+  @test all(x2d1[-9,:] .== 0)
+  @test all(x2d1[8005,:] .== 0)
+  @test all(x2d1[1,:] .== 0)
+  @test x2d1[2,:] == x2d[1,:]
+  @test x2d1[8001,:] == x2d[8000,:]
+  x2d2 = padded(x2d1, (1, 1); delay=0)
+  @test all(x2d2[-10,:] .== 0)
+  @test all(x2d2[8006,:] .== 0)
+  @test x2d2[2,:] == x2d1[2,:] == x2d[1,:]
+  @test x2d2[8001,:] == x2d1[8001,:] == x2d[8000,:]
 
   x1 = padded(x, (10, 5); delay=-2)
   @test x1[-9] == 0
   @test x1[8005] == 0
   @test x1[-1] == x[1]
   @test x1[7998] == x[8000]
+  x2d1 = padded(x2d, (10, 5); delay=-2)
+  @test all(x2d1[-9,:] .== 0)
+  @test all(x2d1[8005,:] .== 0)
+  @test x2d1[-1,:] == x2d[1,:]
+  @test x2d1[7998,:] == x2d[8000,:]
 
   x = signal(collect(1:10), 1.0)
   @test length(collect(partition(x, 5))) == 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -127,6 +127,18 @@ using SignalAnalysis.Units
   @test length(collect(partition(x, 5; step=2, flush=false))) == 3
   @test length(collect(partition(x, 4; step=2, flush=false))) == 4
 
+  pad_x = padded(x, (1, 1))
+  @test iterate(partition(pad_x, 5)) == ([0,1,2,3,4], 5)
+  @test iterate(partition(pad_x, 5), 1) == ([1,2,3,4,5], 6)
+  @test length(collect(partition(pad_x, 5))) == 3
+  @test length(collect(partition(pad_x, 4))) == 3
+  @test length(collect(partition(pad_x, 5; flush=false))) == 2
+  @test length(collect(partition(pad_x, 4; flush=false))) == 3
+  @test length(collect(partition(pad_x, 5; step=2))) == 6
+  @test length(collect(partition(pad_x, 4; step=2))) == 6
+  @test length(collect(partition(pad_x, 5; step=2, flush=false))) == 4
+  @test length(collect(partition(pad_x, 4; step=2, flush=false))) == 5
+
   x = signal(ones(1000), 8kHz)
   x2 = map(enumerate(partition(x, 250))) do (blknum, x1)
     @test size(x1) == (250,)


### PR DESCRIPTION
For `padded`, before the changes:
```julia
julia> x = [1,2,3,4,5];

julia> pad_x = padded(x, (1,1));

julia> pad_pad_x = padded(pad_x, (1,1));

julia> x[1:5]
5-element Vector{Int64}:
 1
 2
 3
 4
 5

julia> pad_x[1:5]
5-element Vector{Int64}:
 1
 2
 3
 4
 5

julia> pad_pad_x[1:5]
5-element Vector{Int64}:
 0
 1
 2
 3
 4

julia> pad_x = padded(signal(randn(10,2), 10), (1,1))
ERROR: MethodError: no method matching padded(::Matrix{Float64}, ::Tuple{Int64, Int64}; delay=0, fill=0.0)
Closest candidates are:
  padded(::MetaArrays.MetaArray{<:Any, SignalAnalysis.SamplingInfo, T}, ::Any; delay, fill) where T at ~/.julia/packages/SignalAnalysis/lEjVN/src/signals.jl:138
  padded(::AbstractVector{T}, ::Any; delay, fill) where T at ~/.julia/packages/SignalAnalysis/lEjVN/src/signals.jl:127
Stacktrace:
 [1] padded(s::MetaArrays.MetaArray{Matrix{Float64}, SignalAnalysis.SamplingInfo, Float64, 2}, padding::Tuple{Int64, Int64}; delay::Int64, fill::Float64)
   @ SignalAnalysis ~/.julia/packages/SignalAnalysis/lEjVN/src/signals.jl:139
 [2] padded(s::MetaArrays.MetaArray{Matrix{Float64}, SignalAnalysis.SamplingInfo, Float64, 2}, padding::Tuple{Int64, Int64})
   @ SignalAnalysis ~/.julia/packages/SignalAnalysis/lEjVN/src/signals.jl:138
 [3] top-level scope
   @ REPL[90]:1
```
After the changes, padded of a vector or matrix with custom indices works.
```julia
julia> pad_pad_x[1:5]
5-element Vector{Int64}:
 1
 2
 3
 4
 5

julia> pad_x = padded(signal(randn(10,2), 10), (1,1))
SampledSignal @ 10.0 Hz, 12×2 PaddedView(0.0, OffsetArray(::Matrix{Float64}, 1:10, 1:2), (0:11, 1:2)) with eltype Float64 with indices 0:11×1:2:
  0.0        0.0
 -0.439627   1.89689
 -0.209597  -0.717943
 -0.328078  -0.37173
 -0.358893  -0.576072
  0.27703    0.0361922
 -0.166934  -0.520583
 -1.91584    0.401654
 -0.334714  -0.201229
 -0.396436   0.181073
 -0.960703   1.54725
  0.0        0.0
```