### PR TITLE
Resample multi-channel signals

### DIFF
--- a/src/dsp.jl
+++ b/src/dsp.jl
@@ -410,8 +410,10 @@ sfiltfilt(coef, x) = signal(filtfilt(coef, samples(x)), framerate(x))
 Same as [`resample`](https://docs.juliadsp.org/stable/filters/#DSP.Filters.resample),
 but correctly handles sampling rate conversion.
 """
-sresample(x, rate) = signal(resample(samples(x), rate), rate * framerate(x))
-sresample(x, rate, coef) = signal(resample(samples(x), rate, coef), rate * framerate(x))
+sresample(x::AbstractVector, rate) = signal(resample(samples(x), rate), rate * framerate(x))
+sresample(x::AbstractVector, rate, coef) = signal(resample(samples(x), rate, coef), rate * framerate(x))
+sresample(x::AbstractMatrix, rate) = signal(resample(samples(x), rate; dims=1), rate * framerate(x))
+sresample(x::AbstractMatrix, rate, coef) = signal(resample(samples(x), rate, coef; dims=1), rate * framerate(x))
 
 # overload DSP versions of the above functions
 DSP.filt(f::AbstractVector{<:Number}, x::SampledSignal) = sfilt(f, x)

--- a/src/dsp.jl
+++ b/src/dsp.jl
@@ -410,10 +410,8 @@ sfiltfilt(coef, x) = signal(filtfilt(coef, samples(x)), framerate(x))
 Same as [`resample`](https://docs.juliadsp.org/stable/filters/#DSP.Filters.resample),
 but correctly handles sampling rate conversion.
 """
-sresample(x::AbstractVector, rate) = signal(resample(samples(x), rate), rate * framerate(x))
-sresample(x::AbstractVector, rate, coef) = signal(resample(samples(x), rate, coef), rate * framerate(x))
-sresample(x::AbstractMatrix, rate) = signal(resample(samples(x), rate; dims=1), rate * framerate(x))
-sresample(x::AbstractMatrix, rate, coef) = signal(resample(samples(x), rate, coef; dims=1), rate * framerate(x))
+sresample(x, rate) = signal(resample(samples(x), rate; dims=1), rate * framerate(x))
+sresample(x, rate, coef) = signal(resample(samples(x), rate, coef; dims=1), rate * framerate(x))
 
 # overload DSP versions of the above functions
 DSP.filt(f::AbstractVector{<:Number}, x::SampledSignal) = sfilt(f, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -549,9 +549,9 @@ end
   @test framerate(x1) == 3 * framerate(x) / 2
   x1 = resample(x, 3//2)
   @test framerate(x1) == 3 * framerate(x) / 2
-  x1 = resample([x x], 3//2; dims=1)
+  x1 = resample([x x], 3//2)
   @test framerate(x1) == 3 * framerate(x) / 2
-  x1 = resample([x x], 3//2, [1,1,1]; dims=1)
+  x1 = resample([x x], 3//2, [1,1,1])
   @test framerate(x1) == 3 * framerate(x) / 2
 
   x = signal(randn(rng, 100), 10kHz)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -549,6 +549,10 @@ end
   @test framerate(x1) == 3 * framerate(x) / 2
   x1 = resample(x, 3//2)
   @test framerate(x1) == 3 * framerate(x) / 2
+  x1 = resample([x x], 3//2; dims=1)
+  @test framerate(x1) == 3 * framerate(x) / 2
+  x1 = resample([x x], 3//2, [1,1,1]; dims=1)
+  @test framerate(x1) == 3 * framerate(x) / 2
 
   x = signal(randn(rng, 100), 10kHz)
   x1 = signal(vcat(zeros(1000), x/2, zeros(1000)), 10kHz)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -541,6 +541,12 @@ end
   @test framerate(x1) == framerate(x)
   x1 = sresample(x, 3//2)
   @test framerate(x1) == 3 * framerate(x) / 2
+  x1 = sresample(x, 3//2, [1,1,1])
+  @test framerate(x1) == 3 * framerate(x) / 2
+  x1 = sresample([x x], 3//2)
+  @test framerate(x1) == 3 * framerate(x) / 2
+  x1 = sresample([x x], 3//2, [1,1,1])
+  @test framerate(x1) == 3 * framerate(x) / 2
   x1 = resample(x, 3//2)
   @test framerate(x1) == 3 * framerate(x) / 2
 


### PR DESCRIPTION
This PR enables resampling on multi-channel signals. 

Before:
```julia
julia> x = cw(7kHz, 1s, 44.1kHz)
julia> sresample([x x], 3//2)
ERROR: UndefKeywordError: keyword argument `dims` not assigned
```
After:
```julia
julia> sresample([x x], 3//2)
SampledSignal @ 66150.0 Hz, 66150×2 Matrix{ComplexF64}:
```