### PR TITLE
Fix `circonv` implementation and add `circcorr`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SignalAnalysis"
 uuid = "df1fea92-c066-49dd-8b36-eace3378ea47"
 authors = ["Mandar Chitre <mandar@nus.edu.sg>"]
-version = "0.9.0"
+version = "0.10.0"
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"

--- a/test/tests-core.jl
+++ b/test/tests-core.jl
@@ -475,20 +475,25 @@ function test_dsp()
   @test y ≈ vcat(zeros(22), 1.0, zeros(22)) atol=0.01
   @test sum(x.^2) ≈ 1.0
 
+  x = rand(rng, 256)
+  @test circcorr(x) ≈ circconv(x, conj.(circshift(reverse(x), 1)))
+
+  x = rand(rng, ComplexF64, 256)
+  @test circcorr(x) ≈ circconv(x, conj.(circshift(reverse(x), 1)))
+
   for j ∈ 2:10
     x = mseq(j)
     @test x isa Array{Float64}
     @test length(x) == 2^j-1
     @test all(abs.(x) .== 1)
-    y = circconv(x)
-    @test all(y .== circconv(x, x))
+    y = circcorr(x)
     @test y[1] ≈ length(x)
     @test all(y[2:end] .≈ -1)
     x = gmseq(j)
     @test x isa Array{ComplexF64}
     @test length(x) == 2^j-1
     @test all(abs.(x) .== 1)
-    y = circconv(x)
+    y = circcorr(x)
     @test y[1] ≈ length(x)
     @test rms(y[2:end]) ≈ 0 atol=1e-10
   end

--- a/test/tests-core.jl
+++ b/test/tests-core.jl
@@ -476,10 +476,16 @@ function test_dsp()
   @test sum(x.^2) ≈ 1.0
 
   x = rand(rng, 256)
-  @test circcorr(x) ≈ circconv(x, conj.(circshift(reverse(x), 1)))
+  y = rand(rng, 256)
+  @test circcorr(x) ≈ circconv(conj.(circshift(reverse(x), 1)), x)
+  @test circcorr(x, y) ≈ circconv(conj.(circshift(reverse(x), 1)), y)
+  @test circconv(x, y) ≈ circconv(y, x)
 
   x = rand(rng, ComplexF64, 256)
-  @test circcorr(x) ≈ circconv(x, conj.(circshift(reverse(x), 1)))
+  y = rand(rng, ComplexF64, 256)
+  @test circcorr(x) ≈ circconv(conj.(circshift(reverse(x), 1)), x)
+  @test circcorr(x, y) ≈ circconv(conj.(circshift(reverse(x), 1)), y)
+  @test circconv(x, y) ≈ circconv(y, x)
 
   for j ∈ 2:10
     x = mseq(j)


### PR DESCRIPTION
Fixes #44

`circcorr` was mistakenly called `circconv` previously. This PR fixes that and adds implementation for `circconv`. It also switches both implementations to use FFTs, as that is faster for longer sequences.